### PR TITLE
76 expand phase ramp and do minor fixes

### DIFF
--- a/src/InSAR/InSAR.jl
+++ b/src/InSAR/InSAR.jl
@@ -16,7 +16,7 @@ _doppler_centroid_frequency(x, dc_param, x0) = dc_param[1] .+ dc_param[2].*(x .-
             dc_tau_0::Float64, fm_coefficient::Vector{Float64},
             fm_tau_0::Float64, f_c::Float64, lines_per_burst::Int64,
             number_of_samples::Int64, delta_t_s::Float64,
-            delta_tau_s::Float64, tau_0::Number, c=LIGHT_SPEED::Real) where T <: Number
+            delta_tau_s::Float64, tau_0::Real, c=LIGHT_SPEED::Real) where T <: Real
 
 Computes the phase ramp (phi) for the given burst number for input rows (lines) and columns (samples).
 
@@ -30,7 +30,7 @@ function phase_ramp(rows::Vector{T}, columns::Vector{T}, burst_number::Int64, v_
                     dc_tau_0::Float64, fm_coefficient::Vector{Float64},
                     fm_tau_0::Float64, f_c::Float64, lines_per_burst::Int64,
                     number_of_samples::Int64, delta_t_s::Float64,
-                    delta_tau_s::Float64, tau_0::Number, c=LIGHT_SPEED::Real) where T <: Number
+                    delta_tau_s::Float64, tau_0::Real, c=LIGHT_SPEED::Real) where T <: Real
 
     if length(rows) != length(columns)
         throw(ArgumentError("Length of rows must match columns. Consider using phase_ramp_grid() for grids"))
@@ -66,7 +66,7 @@ end
 Extracts relevant parameters from meta_data and calls phase_ramp().
 """
 function phase_ramp(rows::Vector{T}, columns::Vector{T},
-                        burst_number::Int64, mid_burst_speed::Float64, meta_data::Sentinel1MetaData) where T <: Number
+                        burst_number::Int64, mid_burst_speed::Float64, meta_data::Sentinel1MetaData) where T <: Real
 
 
     if length(rows) != length(columns)

--- a/src/SARImageInterface.jl
+++ b/src/SARImageInterface.jl
@@ -38,8 +38,7 @@ end
 """
     get_burst_mid_times(image::T) where T <: SingleLookComplex
 
-Returns a vector of the mid burst times for the burst in the image.
-Only bursts included in the image view are included
+Returns a vector of the mid burst times for the burst in the full image
 """
 function get_burst_mid_times(image::T) where T <: SingleLookComplex
     throw(ErrorException("get_burst_mid_times(image::T)   must be implemented for all SingleLookComplex types. Type: $T"))

--- a/src/Sensors/Sentinel1/Sentinel1Types/Sentinel1Types.jl
+++ b/src/Sensors/Sentinel1/Sentinel1Types/Sentinel1Types.jl
@@ -47,7 +47,5 @@ end
 
 function get_burst_mid_times(image::Sentinel1SLC)
     mid_times = get_burst_mid_times(image.metadata)
-    burst_numbers = get_burst_numbers(image)
-
-    return mid_times[burst_numbers]
+    return mid_times
 end

--- a/test/GeoCoding/OrbitStateTest.jl
+++ b/test/GeoCoding/OrbitStateTest.jl
@@ -114,7 +114,8 @@ function interpolation_with_image_test()
 
     ## Assert
     mid_burst_state = SARProcessing.get_burst_mid_states(image,interpolator)
-    speed = SARProcessing.get_speed.(mid_burst_state)
+    burst_number =SARProcessing.get_burst_numbers(image)
+    speed = SARProcessing.get_speed.(mid_burst_state)[first(burst_number)]
 
     testOk = length(speed) == 1  # test image subset only covers one swath
     testOk &= isapprox(7500,speed[1],rtol = 0.1)  #satellite speed is around 7.5 km/s

--- a/test/InSAR/InSARTest.jl
+++ b/test/InSAR/InSARTest.jl
@@ -74,7 +74,7 @@ function phase_ramp_grid_test()
     # ## Get mid burst time and speed
     interpolator = SARProcessing.orbit_state_interpolator(orbit_states, image)
     mid_burst_state = SARProcessing.get_burst_mid_states(image, interpolator)
-    mid_burst_speed = SARProcessing.get_speed.(mid_burst_state)[1]
+    mid_burst_speed = SARProcessing.get_speed.(mid_burst_state)[burst_number]
 
     # Create some matrices of row and column indices
     image_window = SARProcessing.get_window(image)
@@ -112,7 +112,7 @@ function phase_ramp_test()
     # ## Get mid burst time and speed
     interpolator = SARProcessing.orbit_state_interpolator(orbit_states, image)
     mid_burst_state = SARProcessing.get_burst_mid_states(image, interpolator)
-    mid_burst_speed = SARProcessing.get_speed.(mid_burst_state)[1]
+    mid_burst_speed = SARProcessing.get_speed.(mid_burst_state)[burst_number]
 
     # Create some matrices of row and column indices
     columns = collect(11:15)
@@ -149,7 +149,7 @@ function deramp_test()
     # ## Get mid burst time and speed
     interpolator = SARProcessing.orbit_state_interpolator(orbit_states, image)
     mid_burst_state = SARProcessing.get_burst_mid_states(image,interpolator)
-    mid_burst_speed = SARProcessing.get_speed.(mid_burst_state)[1]
+    mid_burst_speed = SARProcessing.get_speed.(mid_burst_state)[burst_number]
 
     # Create some matrices of row and colomn indeces
     image_window = SARProcessing.get_window(image)
@@ -184,7 +184,7 @@ function reramp_test()
     # ## Get mid burst time and speed
     interpolator = SARProcessing.orbit_state_interpolator(orbit_states, image)
     mid_burst_state = SARProcessing.get_burst_mid_states(image,interpolator)
-    mid_burst_speed = SARProcessing.get_speed.(mid_burst_state)[1]
+    mid_burst_speed = SARProcessing.get_speed.(mid_burst_state)[burst_number]
 
     # Create some matrices of row and column indices
     image_window = SARProcessing.get_window(image)

--- a/test/InSAR/InSARTest.jl
+++ b/test/InSAR/InSARTest.jl
@@ -61,6 +61,44 @@ function _doppler_centroid_frequency_test()
     return polynomial_test(SARProcessing._doppler_centroid_frequency, range_time, dc_meta.polynomial, dc_meta.t0)
 end
 
+function phase_ramp_grid_test()
+    ## Arrange
+    # load image
+    image = load_test_slc_image();
+    meta_data = image.metadata;
+    burst_number = SARProcessing.get_burst_numbers(image)[1]
+
+    # get range times from columns/samples
+    orbit_states = SARProcessing.load_precise_orbit_sentinel1(PRECISE_ORBIT_TEST_FILE2)
+
+    # ## Get mid burst time and speed
+    interpolator = SARProcessing.orbit_state_interpolator(orbit_states, image)
+    mid_burst_state = SARProcessing.get_burst_mid_states(image, interpolator)
+    mid_burst_speed = SARProcessing.get_speed.(mid_burst_state)[1]
+
+    # Create some matrices of row and column indices
+    image_window = SARProcessing.get_window(image)
+    columns = image_window[2][1]:image_window[2][2]
+    rows = image_window[1][1]:image_window[1][2]
+
+    ## Act
+    ramp = SARProcessing.phase_ramp_grid(rows, columns, burst_number, mid_burst_speed, meta_data);
+
+    ## Assert
+    # check if output is real
+    output_type = eltype(ramp);
+    check_real = output_type <: Real
+
+    #check size 
+    check_size = size(ramp) == size(image.data)
+
+    # check that the ramp is not all zeros
+    check_non_zero = sum(ramp .!= 0) != 0;
+
+    test_ok = all([check_real, check_non_zero, check_size])
+    return test_ok
+end
+
 function phase_ramp_test()
     ## Arrange
     # load image
@@ -76,10 +114,9 @@ function phase_ramp_test()
     mid_burst_state = SARProcessing.get_burst_mid_states(image, interpolator)
     mid_burst_speed = SARProcessing.get_speed.(mid_burst_state)[1]
 
-    # Create some matrices of row and colomn indeces
-    image_window = SARProcessing.get_window(image)
-    columns = collect(image_window[2][1]:image_window[2][2])
-    rows = collect(image_window[1][1]:image_window[1][2])
+    # Create some matrices of row and column indices
+    columns = collect(11:15)
+    rows = collect(10:-2:1)
 
     ## Act
     ramp = SARProcessing.phase_ramp(rows, columns, burst_number, mid_burst_speed, meta_data);
@@ -89,10 +126,13 @@ function phase_ramp_test()
     output_type = eltype(ramp);
     check_real = output_type <: Real
 
+    # check size
+    check_size = length(ramp) == 5
+
     # check that the ramp is not all zeros
     check_non_zero = sum(ramp .!= 0) != 0;
 
-    test_ok = all([check_real, check_non_zero])
+    test_ok = all([check_real, check_non_zero, check_size])
     return test_ok
 end
 
@@ -113,11 +153,11 @@ function deramp_test()
 
     # Create some matrices of row and colomn indeces
     image_window = SARProcessing.get_window(image)
-    columns = collect(image_window[2][1]:image_window[2][2])
-    rows = collect(image_window[1][1]:image_window[1][2])
+    columns = image_window[2][1]:image_window[2][2]
+    rows = image_window[1][1]:image_window[1][2]
 
     ## Act 
-    ramp = SARProcessing.phase_ramp(rows, columns, burst_number[1], mid_burst_speed, meta_data);
+    ramp = SARProcessing.phase_ramp_grid(rows, columns, burst_number[1], mid_burst_speed, meta_data);
     deramped_image = SARProcessing.deramp(image, ramp)
 
     ## Assert
@@ -146,12 +186,12 @@ function reramp_test()
     mid_burst_state = SARProcessing.get_burst_mid_states(image,interpolator)
     mid_burst_speed = SARProcessing.get_speed.(mid_burst_state)[1]
 
-    # Create some matrices of row and colomn indeces
+    # Create some matrices of row and column indices
     image_window = SARProcessing.get_window(image)
-    columns = collect(image_window[2][1]:image_window[2][2])
-    rows = collect(image_window[1][1]:image_window[1][2])
+    columns = image_window[2][1]:image_window[2][2]
+    rows = image_window[1][1]:image_window[1][2]
 
-    ramp = SARProcessing.phase_ramp(rows, columns, burst_number[1], mid_burst_speed, meta_data);
+    ramp = SARProcessing.phase_ramp_grid(rows, columns, burst_number[1], mid_burst_speed, meta_data);
 
     ## Act
     reramped_image = SARProcessing.reramp(image, ramp)
@@ -170,6 +210,7 @@ end
 @testset "InSARTest.jl" begin
     @test _doppler_centroid_frequency_test()
     @test _doppler_fm_rate_test()
+    @test phase_ramp_grid_test()
     @test phase_ramp_test()
     @test deramp_test()
     @test reramp_test()


### PR DESCRIPTION
The phase_ramp functions is extend to work for row column position not located on a grid. This is need to reramp the secondary image after resampling.

The get_burst_mid_times() function is also changed to return all the mid times for all burst in the original image. It makes it easier to get mid time and state for a specific burst.