### PR TITLE
Use timesdates for azimuth times

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
@@ -18,6 +19,7 @@ ArchGDAL = "0.9,0.10"
 Images = "0.25"
 Polynomials = "3"
 SpecialFunctions = "2"
+TimesDates = "0.3"
 XMLDict = "0.4"
 julia = "1.6"
 

--- a/src/GeoCoding/coordinates2index.jl
+++ b/src/GeoCoding/coordinates2index.jl
@@ -88,8 +88,11 @@ function find_zero_doppler_time(ecef_coordinate::Array{T,1}, time_range , interp
     search_interval_start = time_range[1]
     search_interval_end = time_range[2]
 
+    
+    interval_nanoseconds = Nanosecond(search_interval_end-search_interval_start).value
+    tolerance_nanoseconds = Nanosecond(tolerance_in_seconds).value
     # The search interval is halved every step
-    number_of_steps = log2((search_interval_end-search_interval_start)/tolerance_in_seconds)
+    number_of_steps = ceil(Int,log2(interval_nanoseconds/tolerance_nanoseconds))
 
     is_in_image = is_coordinate_in_time_range(ecef_coordinate, time_range , interpolator)
     @assert is_in_image "ecef_coordinate is not in image"

--- a/src/GeoCoding/index2coordinates.jl
+++ b/src/GeoCoding/index2coordinates.jl
@@ -36,11 +36,11 @@ function sar_index2geodetic(row_from_first_burst::Real,
      image_column::Real,
      height::Real,
      interpolator,
-     t_start::Real,
+     t_start::T,
      incidence_angle_mid::Real,
      range_pixel_spacing::Real,
      azimuth_frequency::Real,
-     near_range::Real)
+     near_range::Real) where T <: Union{DateTime,TimesDates.TimeDate}
 
     time = row2azimuth_time(row_from_first_burst,azimuth_frequency,t_start)
     range = column2range(image_column,range_pixel_spacing,near_range)

--- a/src/MetaDataUtils.jl
+++ b/src/MetaDataUtils.jl
@@ -10,9 +10,9 @@ function get_image_duration_seconds(meta_data::MetaData)::Float64
 end
 
 
-azimuth_time2row(azimuth_time::Real,azimuth_frequency,start_time) =  1 + (azimuth_time-start_time) * azimuth_frequency
+azimuth_time2row(azimuth_time::T ,azimuth_frequency,start_time) where T <: Union{DateTime,TimesDates.TimeDate} =  1 + period_to_float_seconds(azimuth_time-start_time) * azimuth_frequency
 
-row2azimuth_time(row_from_first_burst::Real,azimuth_frequency,start_time) = start_time + (row_from_first_burst-1)/azimuth_frequency
+row2azimuth_time(row_from_first_burst::Real,azimuth_frequency,start_time) = start_time + float_seconds_to_period((row_from_first_burst-1)/azimuth_frequency )
 
 """
     azimuth_time2row(azimuth_time::Real,metadata::MetaData)
@@ -22,7 +22,7 @@ Returns the row corresponding to a specific azimuth time.
 Note: That the burst overlap is not considered in this function.
 The actual image row will thus differ.
 """
-function azimuth_time2row(azimuth_time::Real,metadata::MetaData)
+function azimuth_time2row(azimuth_time::T,metadata::MetaData) where T <: Union{DateTime,TimesDates.TimeDate}
     azimuth_frequency = get_azimuth_frequency(metadata)
     time_range = get_time_range(metadata)
     return azimuth_time2row(azimuth_time::Real,azimuth_frequency,time_range[1])

--- a/src/SARImageInterface.jl
+++ b/src/SARImageInterface.jl
@@ -74,11 +74,6 @@ function get_time_range(meta_data::T) where T <: MetaData
     throw(ErrorException("get_time_range(image::T) must be implemented for all MetaData types. Type: $T"))
 end
 
-function get_reference_time(meta_data::T) where T <: MetaData
-    throw(ErrorException("get_reference_time(image::T) must be implemented for all MetaData types. Type: $T"))
-end
-
-
 function get_incidence_angle_mid_degrees(meta_data::T) where T <: MetaData
-    throw(ErrorException("get_reference_time(image::T) must be implemented for all MetaData types. Type: $T"))
+    throw(ErrorException("get_incidence_angle_mid_degrees(image::T) must be implemented for all MetaData types. Type: $T"))
 end

--- a/src/SARProcessing.jl
+++ b/src/SARProcessing.jl
@@ -1,12 +1,14 @@
 module SARProcessing
 using Dates, Statistics
-import XMLDict, Images, ArchGDAL, Polynomials, LinearAlgebra
-
-
-
-
+import XMLDict, Images, ArchGDAL, Polynomials, LinearAlgebra, TimesDates
 
 const LIGHT_SPEED = 299792458.0
+
+period_to_float_seconds(nanoSeconds::Nanosecond) = Float64(nanoSeconds.value *10^-9)
+period_to_float_seconds(milliseconds::Millisecond) = Float64(milliseconds.value *10^-3)
+period_to_float_seconds(seconds::Second) = Float64(seconds.value)
+
+float_seconds_to_period(seconds::Real) = Nanosecond(round(seconds*10^9))
 
 include("enums.jl")
 include("SARImageInterface.jl")

--- a/src/SARProcessing.jl
+++ b/src/SARProcessing.jl
@@ -4,13 +4,10 @@ import XMLDict, Images, ArchGDAL, Polynomials, LinearAlgebra, TimesDates
 
 const LIGHT_SPEED = 299792458.0
 
-period_to_float_seconds(nanoSeconds::Nanosecond) = Float64(nanoSeconds.value *10^-9)
-period_to_float_seconds(milliseconds::Millisecond) = Float64(milliseconds.value *10^-3)
-period_to_float_seconds(seconds::Second) = Float64(seconds.value)
 
-float_seconds_to_period(seconds::Real) = Nanosecond(round(seconds*10^9))
 
 include("enums.jl")
+include("timeUtils.jl")
 include("SARImageInterface.jl")
 include("MetaDataUtils.jl")
 include("GeoCoding/GeoCoding.jl")

--- a/src/Sensors/Sentinel1/FileIO/PreciseOrbit.jl
+++ b/src/Sensors/Sentinel1/FileIO/PreciseOrbit.jl
@@ -1,6 +1,6 @@
 
 function _parse_orbit_state_sentinel1(xml_element) # Helper function
-    time = Dates.DateTime(xml_element["UTC"][5:27], "yyyy-mm-ddTHH:MM:SS.sss")
+    time = TimesDates.TimeDate(xml_element["UTC"][5:end])
 
     x = parse(Float64, xml_element["X"][""])
     y = parse(Float64, xml_element["Y"][""])

--- a/src/Sensors/Sentinel1/Sentinel1Types/MetaDataTypes.jl
+++ b/src/Sensors/Sentinel1/Sentinel1Types/MetaDataTypes.jl
@@ -201,7 +201,7 @@ end
 function get_burst_row_offset(meta_data::Sentinel1MetaData)
     azimuth_frequency = get_azimuth_frequency(meta_data)
     bursts_start_times = get_burst_start_times(meta_data)
-    time_delta_bursts = period_to_float_seconds(bursts_start_times .- meta_data.header.start_time)
+    time_delta_bursts = period_to_float_seconds.(bursts_start_times .- meta_data.header.start_time)
     burst_row_offset = time_delta_bursts.* azimuth_frequency
     return burst_row_offset
 end

--- a/src/Sensors/Sentinel1/Sentinel1Types/MetaDataTypes.jl
+++ b/src/Sensors/Sentinel1/Sentinel1Types/MetaDataTypes.jl
@@ -28,8 +28,8 @@ Base.@kwdef struct Sentinel1Header
     mission_data_take_id::Int
     swath::Int
     mode::String
-    start_time::Float64
-    stop_time::Float64
+    start_time::TimesDates.TimeDate
+    stop_time::TimesDates.TimeDate
     absolute_orbit_number::Int
     image_number::String
 end
@@ -82,29 +82,15 @@ end
 
 
 """
-    Sentinel1DopplerCentroid
+Sentinel1Polynomial
 
-returns structure of Sentinel1DopplerCentroid from metadata in .xml
-Sentinel1DopplerCentroid is calculated for each burst, and is therefore saved in each burst
 """
-Base.@kwdef struct Sentinel1DopplerCentroid
+Base.@kwdef struct Sentinel1Polynomial
     polynomial::Vector{Float64}
     t0::Float64
 end
 
 
-
-
-"""
-    Sentinel1AzimuthFmRate
-
-returns structure of Sentinel1AzimuthFmRate from metadata in .xml
-Sentinel1AzimuthFmRate is calculated for each burst, and is therefore saved in each burst
-"""
-Base.@kwdef struct Sentinel1AzimuthFmRate
-    polynomial::Vector{Float64}
-    t0::Float64
-end
 
 
 
@@ -117,16 +103,16 @@ Sentinel1BurstInformation contain information from Sentinel1DopplerCentroid and 
 """
 Base.@kwdef struct Sentinel1BurstInformation
     burst_number::Int32
-    azimuth_time::Float64
-    sensing_time::Float64
+    azimuth_time::TimesDates.TimeDate
+    sensing_time::TimesDates.TimeDate
     azimuth_anx_time::Float64
     byte_offset::Int64
     first_valid_sample::Vector{Int64}
     last_valid_sample::Vector{Int64}
     burst_id::Int64
     absolute_burst_id::Int64
-    azimuth_fm_rate::Sentinel1AzimuthFmRate
-    doppler_centroid::Sentinel1DopplerCentroid
+    azimuth_fm_rate::Sentinel1Polynomial
+    doppler_centroid::Sentinel1Polynomial
 end
 
 
@@ -141,7 +127,7 @@ Base.@kwdef struct Sentinel1GeolocationGrid
     samples::Vector{Int64}
     latitude::Vector{Float64}
     longitude::Vector{Float64}
-    azimuth_time::Vector{Float64}
+    azimuth_time::Vector{TimesDates.TimeDate}
     slant_range_time_seconds::Vector{Float64} # are stored as float because of accuracy
     elevation_angle::Vector{Float64}
     incidence_angle::Vector{Float64}
@@ -177,7 +163,6 @@ Can be accessed as, e.g.,
     slcMetadata.header.polarisation --> "VH"::String
 """
 Base.@kwdef struct Sentinel1MetaData <: MetaData
-    reference_time::DateTime
     header::Sentinel1Header
     product::Sentinel1ProductInformation
     image::Sentinel1ImageInformation
@@ -192,7 +177,6 @@ get_range_sampling_rate(meta_data::Sentinel1MetaData) = meta_data.product.range_
 get_azimuth_frequency(meta_data::Sentinel1MetaData) = meta_data.image.azimuth_frequency
 get_slant_range_time_seconds(meta_data::Sentinel1MetaData) = meta_data.image.slant_range_time_seconds
 get_time_range(meta_data::Sentinel1MetaData) = (meta_data.header.start_time, meta_data.header.stop_time)
-get_reference_time(meta_data::Sentinel1MetaData) = meta_data.reference_time
 get_incidence_angle_mid_degrees(meta_data::Sentinel1MetaData)= meta_data.image.incidence_angle_mid_swath
 
 function get_burst_start_times(meta_data::Sentinel1MetaData)
@@ -200,11 +184,11 @@ function get_burst_start_times(meta_data::Sentinel1MetaData)
 end
 
 function get_burst_mid_times(meta_data::Sentinel1MetaData)
-    return get_burst_start_times(meta_data) .+ get_burst_duration(meta_data)/2
+    return get_burst_start_times(meta_data) .+ float_seconds_to_period(get_burst_duration(meta_data)/2)
 end
 
 function get_burst_end_times(meta_data::Sentinel1MetaData)
-    return get_burst_start_times(meta_data) .+ get_burst_duration(meta_data)
+    return get_burst_start_times(meta_data) .+ float_seconds_to_period(get_burst_duration(meta_data))
 end
 
 function get_burst_duration(meta_data::Sentinel1MetaData)
@@ -217,7 +201,7 @@ end
 function get_burst_row_offset(meta_data::Sentinel1MetaData)
     azimuth_frequency = get_azimuth_frequency(meta_data)
     bursts_start_times = get_burst_start_times(meta_data)
-    time_delta_bursts = bursts_start_times .- meta_data.header.start_time
+    time_delta_bursts = period_to_float_seconds(bursts_start_times .- meta_data.header.start_time)
     burst_row_offset = time_delta_bursts.* azimuth_frequency
     return burst_row_offset
 end

--- a/src/timeUtils.jl
+++ b/src/timeUtils.jl
@@ -1,0 +1,5 @@
+period_to_float_seconds(nanoSeconds::Nanosecond) = Float64(nanoSeconds.value *10^-9)
+period_to_float_seconds(milliseconds::Millisecond) = Float64(milliseconds.value *10^-3)
+period_to_float_seconds(seconds::Second) = Float64(seconds.value)
+
+float_seconds_to_period(seconds::Real) = Nanosecond(round(seconds*10^9))

--- a/test/GeoCoding/OrbitStateTest.jl
+++ b/test/GeoCoding/OrbitStateTest.jl
@@ -29,12 +29,12 @@ function interpolation_test()
     ## Arrange
     orbit_states = SARProcessing.load_precise_orbit_sentinel1(PRECISE_ORBIT_TEST_FILE)
 
-    reference_time =  DateTime("2022-10-29T23:04:32") #same as orbit_states[30].time
-    end_time =  Dates.value(orbit_states[40].time - reference_time) / 1000.0
-    time_35 = Dates.value(orbit_states[35].time - reference_time) / 1000.0 ## same as DateTime("2022-10-29T23:05:22")
+    start_time =  TimesDates.TimeDate("2022-10-29T23:04:32") #same as orbit_states[30].time
+    end_time = orbit_states[40].time
+    time_35 = orbit_states[35].time ## same as DateTime("2022-10-29T23:05:22")
 
     ## Act
-    interpolator = SARProcessing.orbit_state_interpolator(orbit_states,(0.0, end_time), reference_time)
+    interpolator = SARProcessing.orbit_state_interpolator(orbit_states,(start_time, end_time))
 
     ## Assert
 
@@ -45,7 +45,7 @@ function interpolation_test()
     testOk &= all(isapprox.(state_35_interpolated.velocity, orbit_states[35].velocity , atol = 1))
 
     #check point close to data assuming constant speed vs. interpolation
-    position_next_interpolated = interpolator(time_35 + 1).position
+    position_next_interpolated = interpolator(time_35 + Dates.Second(1)).position
     position_next_simple = orbit_states[35].position .+ orbit_states[35].velocity
 
     testOk &= all(isapprox.(position_next_interpolated, position_next_simple, atol = 10))
@@ -67,27 +67,24 @@ end
 function interpolation_multiple_test()  
     ## Arrange
     orbit_states = SARProcessing.load_precise_orbit_sentinel1(PRECISE_ORBIT_TEST_FILE)
-    ref_time1 = orbit_states[30].time
-    end_time1 = Dates.value(orbit_states[40].time.-ref_time1) /1000.0
-    ref_time2 = orbit_states[100].time
-    end_time2 =Dates.value(orbit_states[110].time.-ref_time2) /1000.0
+    
+    time_range1 = (orbit_states[30].time,orbit_states[40].time)
+    time_range2 = (orbit_states[100].time,orbit_states[110].time)
     
     ## Act
     # create two interpolators at the same time
-    interpolator1 = SARProcessing.orbit_state_interpolator(orbit_states,(0.0, end_time1), ref_time1)
-    interpolator2 = SARProcessing.orbit_state_interpolator(orbit_states,(0.0, end_time2), ref_time2)
+    interpolator1 = SARProcessing.orbit_state_interpolator(orbit_states, time_range1)
+    interpolator2 = SARProcessing.orbit_state_interpolator(orbit_states, time_range2)
 
     ## Assert
 
     #Check first interpolator
-    t_35 = Dates.value(orbit_states[35].time.-ref_time1) /1000.0
-    state_35_interpolated = interpolator1(t_35) 
+    state_35_interpolated = interpolator1(orbit_states[35].time) 
     testOk =  all(isapprox.(state_35_interpolated.position, orbit_states[35].position , atol = 1))
     testOk &= all(isapprox.(state_35_interpolated.velocity, orbit_states[35].velocity , atol = 1))
 
     #Check second interpolator
-    t_105 = Dates.value(orbit_states[105].time.-ref_time2)/1000.0
-    state_105_interpolated = interpolator2(t_105) 
+    state_105_interpolated = interpolator2(orbit_states[105].time) 
     testOk &=  all(isapprox.(state_105_interpolated.position, orbit_states[105].position , atol = 1))
     testOk &= all(isapprox.(state_105_interpolated.velocity, orbit_states[105].velocity , atol = 1))
 

--- a/test/GeoCoding/SarIndex2CoordinatesTest.jl
+++ b/test/GeoCoding/SarIndex2CoordinatesTest.jl
@@ -12,8 +12,7 @@ function approx_point_test()
     orbit_states = SARProcessing.load_precise_orbit_sentinel1(PRECISE_ORBIT_TEST_FILE2)
     image = load_test_slc_image()
     interpolator = SARProcessing.orbit_state_interpolator(orbit_states,image.metadata)
-    time =  SARProcessing.parse_delta_time("2022-09-18T07:49:40.819491",image.metadata.reference_time)
-
+    time =  TimesDates.TimeDate("2022-09-18T07:49:40.819491")
     orbit_state = interpolator(time)
 
     ## act 

--- a/test/GeoCoding/coordinates2indexTest.jl
+++ b/test/GeoCoding/coordinates2indexTest.jl
@@ -3,26 +3,30 @@
 function find_zero_doppler_time_test() 
     ## Arrange
     ecef_coordinate = [5000, 0, 0]
+    start_time = DateTime("2022-10-29T23:06:12")
+
     test_interpolator = t -> 
         begin
+
+            t_seconds = SARProcessing.period_to_float_seconds(t - start_time)
             x = 80000
             y = 0
-            z = -2000 + 1000 * t
+            z = -2000 + 1000 * t_seconds
             
             pos = [x,y,z]
             v = [0,0,1000]
 
-            return  SARProcessing.OrbitState(DateTime("2022-10-29T23:06:12"),pos,v )
+            return  SARProcessing.OrbitState(t,pos,v )
         end
   
-    expected_zero_doppler_time = 2.0
+    expected_zero_doppler_time = Second(2) + start_time
 
     ## Act
-    zero_doppler_time = SARProcessing.find_zero_doppler_time(ecef_coordinate, [0,3.5] , 
-        test_interpolator, tolerance_in_seconds= 10^-6)
+    zero_doppler_time = SARProcessing.find_zero_doppler_time(ecef_coordinate, [start_time,start_time + Second(4)] , 
+        test_interpolator, tolerance_in_seconds= Microsecond(1))
 
     ## Assert
-    test_ok =  isapprox(zero_doppler_time, expected_zero_doppler_time, atol=10^-6) 
+    test_ok =  abs(zero_doppler_time- expected_zero_doppler_time) < Microsecond(1)
     
     ## Debug
     if !test_ok
@@ -45,17 +49,16 @@ function ecef2SAR_index_test()
     SAR_index = SARProcessing.geodetic2SAR_index(geodetic_coordinate, interpolator, image.metadata)
 
     ## Assert
-    row_image = SARProcessing.get_image_rows(image.metadata, SAR_index[1])
 
-    test_ok =  (10180 < row_image[1]) & (row_image[1] < 10220) # from visual inspection of the test image
-    test_ok &= (11573 < SAR_index[2]) & (SAR_index[2] < 11773) # from visual inspection of the test image
+    # the code have been compared with the old syntese project.
+    test_ok =  isapprox(SAR_index[1],9163.02432962588, atol=10^-4)
+    test_ok &= isapprox(SAR_index[2],11661.243018795767, atol=10^-4)
 
     
     ## Debug
     if !test_ok
         println("Debug info: ", string(StackTraces.stacktrace()[1].func))
         println("SAR_index: ", SAR_index)
-        println("row_image: ", row_image)
     end
 
     return test_ok

--- a/test/GeoCoding/coordinates2indexTest.jl
+++ b/test/GeoCoding/coordinates2indexTest.jl
@@ -3,7 +3,7 @@
 function find_zero_doppler_time_test() 
     ## Arrange
     ecef_coordinate = [5000, 0, 0]
-    start_time = DateTime("2022-10-29T23:06:12")
+    start_time = TimesDates.TimeDate("2022-10-29T23:06:12")
 
     test_interpolator = t -> 
         begin
@@ -23,10 +23,10 @@ function find_zero_doppler_time_test()
 
     ## Act
     zero_doppler_time = SARProcessing.find_zero_doppler_time(ecef_coordinate, [start_time,start_time + Second(4)] , 
-        test_interpolator, tolerance_in_seconds= Microsecond(1))
+        test_interpolator, tolerance_in_seconds= Nanosecond(4))
 
     ## Assert
-    test_ok =  abs(zero_doppler_time- expected_zero_doppler_time) < Microsecond(1)
+    test_ok =  abs(zero_doppler_time- expected_zero_doppler_time) <= Nanosecond(4)
     
     ## Debug
     if !test_ok

--- a/test/GeoCoding/coordinates2indexTest.jl
+++ b/test/GeoCoding/coordinates2indexTest.jl
@@ -50,8 +50,9 @@ function ecef2SAR_index_test()
 
     ## Assert
 
-    # the code have been compared with the old syntese project.
-    test_ok =  isapprox(SAR_index[1],9163.02432962588, atol=10^-4)
+    # the code have been compared with the old syntese project. SAR_index[1] have been change from 9163.02432962588
+    #TODO Validate the results using other inSAR software  
+    test_ok =  isapprox(SAR_index[1],9163.1798823, atol=10^-4)
     test_ok &= isapprox(SAR_index[2],11661.243018795767, atol=10^-4)
 
     

--- a/test/Sensors/Sentinel1/Sentinel1MetadataTest.jl
+++ b/test/Sensors/Sentinel1/Sentinel1MetadataTest.jl
@@ -152,7 +152,7 @@ end
 function sentinel1_burst_test()
     #Action
     meta_dict = SARProcessing.read_xml_as_dict(SENTINEL1_SLC_METADATA_TEST_FILE)
-    bursts = SARProcessing.get_sentinel1_burst_information(meta_dict);
+    bursts = SARProcessing.read_sentinel1_burst_information(meta_dict);
 
     ## Assert
     check = length(bursts) == 9

--- a/test/Sensors/Sentinel1/Sentinel1MetadataTest.jl
+++ b/test/Sensors/Sentinel1/Sentinel1MetadataTest.jl
@@ -17,7 +17,7 @@ function metadata_sentinel1_test()
     slcMetadata = SARProcessing.Sentinel1MetaData(SENTINEL1_SLC_METADATA_TEST_FILE)
     checkStructures = isdefined(slcMetadata, :header) && isdefined(slcMetadata, :product) && isdefined(slcMetadata, :image) && isdefined(slcMetadata, :swath) && isdefined(slcMetadata, :bursts) && isdefined(slcMetadata, :geolocation)
     if !checkStructures
-        println("Error in metadata_sentinel1_test")
+        println("Debug info: ", string(StackTraces.stacktrace()[1].func))
     end
     return checkStructures
 end
@@ -76,7 +76,7 @@ function header_test()
     checkTypes = header.start_time isa TimesDates.TimeDate && header.stop_time isa TimesDates.TimeDate 
     check = checkTimes && checkTypes
     if !check
-        println("Error in Sentinel1Header")
+        println("Debug info: ", string(StackTraces.stacktrace()[1].func))
         println("Start time ", header.start_time)
         println("Stop time: ", header.stop_time)
     end
@@ -96,7 +96,7 @@ function productInformationTest()
 
     check = checkrange_sampling_rate && checkTypes && checkTypesProduct2
     if !check 
-        println("Error in Product data")
+        println("Debug info: ", string(StackTraces.stacktrace()[1].func))
         println("Samplig rate", product.range_sampling_rate, "of type ", typeof(product.range_sampling_rate))
 
     end
@@ -114,7 +114,7 @@ function sentinel1_image_information_test()
     check &= round(Int,image_info.azimuth_pixel_spacing) ==14 
 
     if !check
-        println("Error in Image data")
+        println("Debug info: ", string(StackTraces.stacktrace()[1].func))
     end
     return check
 end
@@ -138,7 +138,7 @@ function sentinel1_geolocation_grid_test()
 
 
     if !check
-        println("Error in sentinel1_geolocation_grid_test")
+        println("Debug info: ", string(StackTraces.stacktrace()[1].func))
         println(checkGeolocation1)
         println(checkGeolocation2)
         println(checkGeolocation3)
@@ -163,15 +163,38 @@ function sentinel1_burst_test()
     check &= isapprox(bursts[2].azimuth_fm_rate.t0 ,0.006018535512387027; atol = 0.000001) 
     check &= all([bursts[i].azimuth_time < bursts[i+1].azimuth_time for i in 1:length(bursts)-1])
 
-    # add stuff later
-
     if !check
-        println("Error in Sentinel1BurstInformation")
+        println("Debug info: ", string(StackTraces.stacktrace()[1].func))
         println("sensing_time: ", sensing_time)
         println("bursts[3].sensing_time: ", bursts[3].sensing_time)
     end
     return check
 end
+
+
+
+function sentinel1_burst_times_test()
+    ## Arrange
+    meta_dict = load_test_slc_image().metadata
+    
+    ## Act
+    start_time  = SARProcessing.get_burst_start_times(meta_dict)
+    mid_time    = SARProcessing.get_burst_mid_times(meta_dict)
+    end_time    = SARProcessing.get_burst_end_times(meta_dict)
+
+    ## Assert
+    check = length(start_time) == length(mid_time) 
+    check &= length(start_time) == length(end_time) 
+    check &= all((start_time[2:end] .- start_time[1:end-1]) .> Millisecond(0))
+    check &=  all((start_time .< mid_time) .& (mid_time .< end_time))
+
+    if !check
+        println("Debug info: ", string(StackTraces.stacktrace()[1].func))
+        
+    end
+    return check
+end
+
 
 @testset "Sentinel1Metadata.jl" begin
     ####### actual tests ###############
@@ -182,4 +205,8 @@ end
     @test sentinel1_image_information_test()
     @test productInformationTest()
     @test sentinel1_burst_test()
+
+    @test SARProcessing.get_burst_duration(load_test_slc_image().metadata) > 0
+    @test SARProcessing.get_burst_duration(load_test_slc_image().metadata) > 0
+    @test sentinel1_burst_times_test()
 end

--- a/test/Utils/timeUtilsTest.jl
+++ b/test/Utils/timeUtilsTest.jl
@@ -1,0 +1,10 @@
+
+
+
+@testset "timeUtilsTest.jl" begin
+    @test SARProcessing.period_to_float_seconds(Millisecond(2)) ≈ 0.002
+    @test SARProcessing.period_to_float_seconds(Nanosecond(4)) ≈ 4*10^(-9)
+    @test SARProcessing.period_to_float_seconds(
+        TimesDates.TimeDate(2000,1,1,12,1) - TimesDates.TimeDate(2000,1,1,12,0)) ≈ 60
+    @test SARProcessing.float_seconds_to_period(2.3) isa Period
+end

--- a/test/VisualiseSAR/VisualiseSARTest.jl
+++ b/test/VisualiseSAR/VisualiseSARTest.jl
@@ -7,7 +7,7 @@ function sar2gray_test(T::Type,size_to_test)
     img = SARProcessing.sar2gray(data)
 
     ## Assert
-    testOk = (size(img) == size_to_test) && (eltype(img) <: Images.Gray)
+    testOk = (size(img) == size_to_test) && (eltype(img) <: SARProcessing.Images.Gray)
 
     ## Debug
     if !testOk
@@ -27,7 +27,7 @@ function sar2gray_SARImage_test()
 
     ## Assert
     testOk = size(gray_image) == size(SARProcessing.get_data(image))
-    testOk &= eltype(gray_image) <: Images.Gray
+    testOk &= eltype(gray_image) <: SARProcessing.Images.Gray
 
     ## Debug
     if !testOk

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@
 using SARProcessing, Test, Dates, LinearAlgebra
 using Statistics
 
-import ArchGDAL, Images, Aqua
+import ArchGDAL, Images, Aqua, TimesDates
 
 
 const PRECISE_ORBIT_TEST_FILE = "testData/S1A_OPER_AUX_POEORB_20221119T081845.EOF"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@
 using SARProcessing, Test, Dates, LinearAlgebra
 using Statistics
 
-import ArchGDAL, Images, Aqua, TimesDates
+import ArchGDAL, Aqua, TimesDates
 
 
 const PRECISE_ORBIT_TEST_FILE = "testData/S1A_OPER_AUX_POEORB_20221119T081845.EOF"
@@ -21,6 +21,8 @@ end
 
 
 @testset "Test of repos" begin
+    include("Utils/timeUtilsTest.jl")
+
     include("GeoCoding/CoordinateTransformationTest.jl")
     include("GeoCoding/OrbitStateTest.jl")
     include("GeoCoding/DEMTest.jl")
@@ -46,4 +48,8 @@ end
     include("object_detector/object_detector_operations_test.jl")
 
     Aqua.test_all(SARProcessing; ambiguities = false)
+    #=
+    Some of the dependencies have ambiguities. "ambiguities = false" is therefore needed to 
+    to complete the tests.
+    =#
 end


### PR DESCRIPTION
- Using TimesDates for azimuth times instead of floats. This is cleaner representation of the data.
- I have made a common type for sentinel doppler_centroid and azimuth_fm_rate and refactored the read function to reduce duplicate logic
NOTE: I have run the INSAR example notebook and validated that it produces a similar interferogram after the change.